### PR TITLE
Make sure grafana works behind reverse proxy

### DIFF
--- a/public/app/controllers/loginCtrl.js
+++ b/public/app/controllers/loginCtrl.js
@@ -78,7 +78,7 @@ function (angular, config) {
         if (result.redirectUrl) {
           window.location.href = result.redirectUrl;
         } else {
-          window.location.href = config.appSubUrl + '/';
+          window.location.href = document.URL + '/';
         }
       });
     };

--- a/public/app/core/routes/all.js
+++ b/public/app/core/routes/all.js
@@ -200,6 +200,14 @@ define([
         templateUrl: 'app/features/health/partials/systemHealth.html',
         controller: 'SystemHealthCtrl',
       })
+      .when('/kibana', {
+        templateUrl: 'app/partials/login.html',
+        controller : 'LoginCtrl',
+      })
+      .when('/kibana:rest*', {
+        templateUrl: 'app/partials/login.html',
+        controller : 'LoginCtrl',
+      })
       .otherwise({
         templateUrl: 'app/partials/error.html',
         controller: 'ErrorCtrl'


### PR DESCRIPTION
I'm trying to add a reverse proxy in front of both Kibana and Grafana. It will work like this. If you go the the proxy (e.g. www.proxy.com), it will redirect you to Grafana at the backend. If you want to use Kibana, point your browser to www.proxy.com/kibana. It will redirect you to Kibana, unless you haven't signed in yet. In which case it will redirect you to Grafana's login page. Once you signed in, it will take you back to where you originally wanted to go.

In order to make this whole thing work, I need to make these changes. I have never worked on AngularJS, so please review these carefully, in case I broken something. Or let me know if there's a better way to do it.

Thanks.
Yongtao