### PR TITLE
log-search-results-improve

### DIFF
--- a/public/app/features/dashboard/timepicker/timepicker.ts
+++ b/public/app/features/dashboard/timepicker/timepicker.ts
@@ -95,7 +95,7 @@ export class TimePickerCtrl {
     this.isOpen = true;
     this.timeOptions = rangeUtil.getRelativeTimesList(this.panel, this.rangeString);
     this.refresh = {
-      value: this.dashboard.refresh,
+      value: this.dashboard.refresh || '1m',
       options: _.map(this.panel.refresh_intervals, (interval: any) => {
         return {text: interval, value: interval};
       })

--- a/public/app/features/logs/logsCtrl.js
+++ b/public/app/features/logs/logsCtrl.js
@@ -57,7 +57,7 @@ define([
               "span": 12,
               "styles": [
                 {
-                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss.sss",
                   "pattern": "@timestamp",
                   "type": "date"
                 },
@@ -136,7 +136,7 @@ define([
               "span": 12,
               "styles": [
                 {
-                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss.sss",
                   "pattern": "@timestamp",
                   "type": "date"
                 },
@@ -220,7 +220,7 @@ define([
               "span": 12,
               "styles": [
                 {
-                  "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                  "dateFormat": "YYYY-MM-DD HH:mm:ss.sss",
                   "pattern": "Time",
                   "type": "date"
                 }
@@ -356,7 +356,6 @@ define([
                 "short",
                 "short"
               ],
-              "interval": "30m",
               "links": [],
               "helpInfo": {
                 "info": false,
@@ -423,7 +422,8 @@ define([
             title: "整合分析",
             id: "123",
             rows: panelMetas,
-            time: {from: "now-6h", to: "now"}
+            time: {from: "now-6h", to: "now"},
+            refresh: "1m",
           }
         }, $scope);
       };

--- a/public/app/features/logs/partials/logs.html
+++ b/public/app/features/logs/partials/logs.html
@@ -48,11 +48,14 @@
                 </div>
                 <tabset>
                     <tab heading="{{panel.title}}" ng-repeat="(name, panel) in row.panels track by panel.id" ng-if="panel.tab != graph">
-                        <li ng-repeat="(index, obj) in panel.regularResult.regularities" ng-if="panel.regularResult.regularities.length">
+                        <!--<li ng-repeat="(index, obj) in panel.regularResult.regularities" ng-if="panel.regularResult.regularities.length">
                             <span ng-repeat="(name,value) in obj">
                                 {{name}}: {{value}}
                             </span>
-                        </li>
+                        </li>-->
+                        <ul ng-if="panel.regularResult.data[0].total">
+                            <li>该时间区域内共有 <strong>{{panel.regularResult.data[0].total}}</strong> 条日志，当前显示前 {{panel.regularResult.data[0].datapoints.length}} 条。放大时间区域，以查看更细日志数据。</li>
+                        </ul>
                         <div class="btn-group btn-log-compare" ng-if="name == 2">
                             <button class="dropdown-toggle" data-toggle="dropdown">
                                 <span class="caret"></span>


### PR DESCRIPTION
1  日志查询中，目前只读取了前500条。优化：展示出总的日志数以避免用户误会，@timestamp展示细化到毫秒。
2  fix： 日志总数显示“数据溢出”的问题